### PR TITLE
added `apt-get update` before `apt-get install`

### DIFF
--- a/files/setup_debian.sh
+++ b/files/setup_debian.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+apt-get update
 apt-get install -y linux-headers-`uname -r` dkms || exit 1
 mount /tmp/VBoxGuestAdditions.iso -o loop /mnt
 /mnt/VBoxLinuxAdditions.run --nox11


### PR DESCRIPTION
if this plugin is run before provisioning the lists won't be updated so I added `apt-get update` before the install. I updated the lists manually and the guest additions could be installed. I hope this is the right place for the fix.
