### PR TITLE
add fedora to install with generic script

### DIFF
--- a/lib/vagrant-vbguest/installer.rb
+++ b/lib/vagrant-vbguest/installer.rb
@@ -76,7 +76,7 @@ module VagrantVbguest
       case platform
       when :debian, :ubuntu
         File.expand_path("../../../files/setup_debian.sh", __FILE__)
-      when :gentoo, :redhat, :suse, :arch, :linux
+      when :gentoo, :redhat, :suse, :arch, :fedora, :linux
         @vm.ui.warn(I18n.t("vagrant.plugins.vbguest.generic_install_script_for_platform", :platform => platform.to_s))
         File.expand_path("../../../files/setup_linux.sh", __FILE__)
       else


### PR DESCRIPTION
I simply added Fedora to the installer.rb. It works at least with Fedora16. Please let me know if I should do something more for Fedora compatibility. 

thanks,

ben
