### PR TITLE
Reboot the VM after installing new additions.

### DIFF
--- a/lib/vagrant-vbguest/installer.rb
+++ b/lib/vagrant-vbguest/installer.rb
@@ -4,12 +4,14 @@ module VagrantVbguest
 
   class Installer
 
-    def initialize(vm, options = {})
+    def initialize(vm, run_env, options = {})
       @env = {
         :ui => vm.ui,
         :tmp_path => vm.env.tmp_path
       }
       @vm = vm
+      @action_runner = run_env[:action_runner]
+      @run_env = run_env
       @iso_path = nil
       @options = options
     end
@@ -56,6 +58,9 @@ module VagrantVbguest
           @vm.channel.execute("rm #{installer_destination} #{iso_destination}") do |type, data|
             @vm.ui.error(data.chomp, :prefix => false)
           end
+
+          @vm.ui.info(I18n.t("vagrant.plugins.vbguest.restart_vm"))
+          reboot_vm 
         end
       end
     ensure
@@ -120,6 +125,10 @@ module VagrantVbguest
     def cleanup
       @download.cleanup if @download
     end
-
+    
+    def reboot_vm
+       @action_runner.run(Vagrant::Action::VM::Halt, @run_env)
+       @action_runner.run(Vagrant::Action::VM::Boot, @run_env)
+    end
   end
 end

--- a/lib/vagrant-vbguest/middleware.rb
+++ b/lib/vagrant-vbguest/middleware.rb
@@ -13,7 +13,7 @@ module VagrantVbguest
 
     def call(env)
       options = @vm.config.vbguest.to_hash
-      VagrantVbguest::Installer.new(@vm, options).run
+      VagrantVbguest::Installer.new(@vm, env, options).run
       @app.call(env)
     end
   end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,6 +8,7 @@ en:
         installing_forced: "Forcing installation of Virtualbox Guest Additions %{host} - guest's version is %{guest}"
         start_copy_iso: "Copy iso file %{from} into the box %{to}"
         start_copy_script: "Copy installer file %{from} into the box %{to}"
+        restart_vm: "Restarting VM to apply changes..."
         no_install_script_for_platform: "Sorry, don't know how to install on a %{platform} system. Stopping installation."
         generic_install_script_for_platform: "%{platform} is currently not supported, will try generic Linux method..."
 


### PR DESCRIPTION
This prevents problems with doing things that require the guest additions like
setting up shared folders or port forwardings.
