### PR TITLE
Fix [gh-27] where provisioning may run twice

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -158,6 +158,13 @@ The `auto-reboot` is tured off by default, when running as a command. Vbguest wi
 $ vagrant vbguest --auto-reboot
 ```
 
+You can also pass vagrant's `reload` options like:
+
+```bash
+$ vagrant vbguest --auto-reboot --no-provision
+```
+
+
 
 ### ISO autodetection
 

--- a/lib/vagrant-vbguest/helpers.rb
+++ b/lib/vagrant-vbguest/helpers.rb
@@ -37,5 +37,29 @@ module VagrantVbguest
       end
 
     end
+
+    module Rebootable
+      @@rebooted = {}
+
+      def rebooted?(vm)
+        !!@@rebooted[vm.name]
+      end
+
+      def need_reboot?(vm)
+        !VagrantVbguest::Helpers.kernel_module_running?(vm)
+      end
+
+      def reboot(vm, options)
+        if options[:auto_reboot]
+          vm.ui.warn(I18n.t("vagrant.plugins.vbguest.restart_vm"))
+          @@rebooted[vm.name] = true
+          true
+        else
+          @vm.ui.warn(I18n.t("vagrant.plugins.vbguest.suggest_restart", :name => vm.name))
+          false
+        end
+      end
+    end
+
   end
 end

--- a/lib/vagrant-vbguest/installer.rb
+++ b/lib/vagrant-vbguest/installer.rb
@@ -3,7 +3,6 @@ module VagrantVbguest
   # Handles the guest addins installation process
 
   class Installer
-    @@rebooted = {}
 
     def initialize(vm, options = {})
       @env = {
@@ -32,12 +31,8 @@ module VagrantVbguest
       @vm.ui.warn(I18n.t("vagrant.plugins.vbguest.check_failed", :host => vb_version, :guest => guest_version)) if @options[:no_install]
 
       if @options[:force] || (!@options[:no_install] && needs_update?)
-        if rebooted?
-          @vm.ui.error(I18n.t("vagrant.plugins.vbguest.restart_loop_guard_activated"))
-        else
-          @vm.ui.warn(I18n.t("vagrant.plugins.vbguest.installing#{@options[:force] ? '_forced' : ''}", :host => vb_version, :guest => guest_version))
-          install
-        end
+        @vm.ui.warn(I18n.t("vagrant.plugins.vbguest.installing#{@options[:force] ? '_forced' : ''}", :host => vb_version, :guest => guest_version))
+        install
       end
     ensure
       cleanup
@@ -67,24 +62,7 @@ module VagrantVbguest
         end
 
         cleanup
-        reboot
       end
-    end
-
-    def reboot
-      if !VagrantVbguest::Helpers.kernel_module_running?(@vm)
-        if @options[:auto_reboot]
-          @vm.ui.warn(I18n.t("vagrant.plugins.vbguest.restart_vm"))
-          @@rebooted[@vm.name] = true
-          @vm.reload(@options[:run_env])
-        else
-          @vm.ui.warn(I18n.t("vagrant.plugins.vbguest.suggest_restart", :name => @vm.name))
-        end
-      end
-    end
-
-    def rebooted?
-      !!@@rebooted[@vm.name]
     end
 
     def needs_update?


### PR DESCRIPTION
Moved the reload handling from the Installer into the Middleware and Command. Both handle reload slightly different.
Also the Command can now be called with reload command options.
