### PR TITLE
Added French locale

### DIFF
--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -46,7 +46,7 @@ fr:
             generic_linux_installer: |-
               La platforme de la VM n'est pas supportée encore, utilisation d'une méthode générique pour Linux...
             do_not_inherit_match_method: |-
-              Installer classes must provide their own `match?` method.
+              Veuillez créer votre propre fonction `match?`.
 
         download:
           with: "Téléchargment de l'ISO VirtualBox GuestAdditions avec %{class}..."


### PR DESCRIPTION
Merged all your changes from your release/0.6 branch.

I am not sure about this part:

```
do_not_inherit_match_method: |-
          Installer classes must provide their own `match?` method.
```

I believe it's too technical to be translated into French and should be left alone. But anyone is free to propose a change.

Thanks again for the great work! Es ist uber.
