### PR TITLE
be lax about missing installer

### DIFF
--- a/lib/vagrant-vbguest/command.rb
+++ b/lib/vagrant-vbguest/command.rb
@@ -80,6 +80,8 @@ module VagrantVbguest
       end
 
       reboot!(vm, options) if _rebootable && machine.reboot?
+    rescue VagrantVbguest::Installer::NoInstallerFoundError => e
+      vm.env.ui.error e.message
     end
 
     def check_runable_on(vm)

--- a/lib/vagrant-vbguest/middleware.rb
+++ b/lib/vagrant-vbguest/middleware.rb
@@ -25,7 +25,9 @@ module VagrantVbguest
         machine.run
         reboot(vm, options) if machine.reboot?
       end
-
+    rescue VagrantVbguest::Installer::NoInstallerFoundError => e
+      vm.env.ui.error e.message
+    ensure
       @app.call(env)
     end
 


### PR DESCRIPTION
Don't throw an error when we cannot find a Installer for the guest os.
Display the error message, stop vbguest workflow, but keep vagrant running.

ref #65
