### PR TITLE
Hook after `WaitForCommunicator` action if it exists

### DIFF
--- a/lib/vagrant-vbguest.rb
+++ b/lib/vagrant-vbguest.rb
@@ -46,7 +46,11 @@ module VagrantVbguest
     # hook after anything that boots:
     # that's all middlewares which will run the buildin "VM::Boot" action
     action_hook('vbguest') do |hook|
-      hook.after(VagrantPlugins::ProviderVirtualBox::Action::Boot, VagrantVbguest::Middleware)
+      if defined?(Vagrant::Action::Builtin::WaitForCommunicator)
+        hook.after(Vagrant::Action::Builtin::WaitForCommunicator, VagrantVbguest::Middleware)
+      else
+        hook.after(VagrantPlugins::ProviderVirtualBox::Action::Boot, VagrantVbguest::Middleware)
+      end
     end
   end
 end


### PR DESCRIPTION
Vagrant 1.3.0 introduced (mitchellh/vagrant@261d0ef) new `WaitForCommunicator` action that ensures the VM is booted and ready for SSH connections. So hook after it if it exists. The default still stays to hook right after the `Boot` action.

The error without the fix is:

```
Guest-specific operations were attempted on a machine that is not
ready for guest communication. This should not happen and a bug
should be reported.
```

Also fix the argument passed to [Plugin.action_hook](https://github.com/mitchellh/vagrant/blob/v1.3.4/lib/vagrant/plugin/v2/plugin.rb#L72) which should be _our_ hook name (although currently not used for anything).
