### PR TITLE
Wait for SSH connection after rebooting the machine

### DIFF
--- a/lib/vagrant-vbguest/vagrant_compat/vagrant_1_1/rebootable.rb
+++ b/lib/vagrant-vbguest/vagrant_compat/vagrant_1_1/rebootable.rb
@@ -13,6 +13,9 @@ module VagrantVbguest
               end
             end
             b.use VagrantPlugins::ProviderVirtualBox::Action::Boot
+            if defined?(Vagrant::Action::Builtin::WaitForCommunicator)
+              b.use Vagrant::Action::Builtin::WaitForCommunicator, [:starting, :running]
+            end
           end
           @env[:action_runner].run(simle_reboot, @env)
         end


### PR DESCRIPTION
Ensure that the VM is accessible after we reboot it.

This also makes sure that the guest addition version is reported correctly after upgrading. (I still get three times the `guest_version_reports_differ` warning before booting.)

This should complete the fix for #80, #81, and #85.
