### PR TITLE
Plugin definition should match the actual gem name

### DIFF
--- a/lib/vagrant-vbguest.rb
+++ b/lib/vagrant-vbguest.rb
@@ -28,7 +28,7 @@ module VagrantVbguest
 
   class Plugin < Vagrant.plugin("2")
 
-    name "vbguest management"
+    name "vagrant-vbguest"
     description <<-DESC
     Provides automatic and/or manual management of the
     VirtualBox Guest Additions inside the Vagrant environment.


### PR DESCRIPTION
This PR allows the use of `Vagrant.has_plugin?` like this:

``` ruby
if Vagrant.has_plugin?('vagrant-vbguest')
  config.vbguest.auto_update = false
else
  abort(%Q|Please run 'vagrant plugin install --plugin-source https://rubygems.org/ --plugin-prerelease vagrant-vbguest'|)
end
```

Currently the only way to have this working is by matching the plugin definition `vbguest management`:

``` ruby
if Vagrant.has_plugin?('vbguest management')
  config.vbguest.auto_update = false
else
  abort(%Q|Please run 'vagrant plugin install --plugin-source https://rubygems.org/ --plugin-prerelease vagrant-vbguest'|)
end
```

Thanks!
