### PR TITLE
Fix `nil[]` error with unknown Vagrant version

### DIFF
--- a/lib/vagrant-vbguest/vagrant_compat.rb
+++ b/lib/vagrant-vbguest/vagrant_compat.rb
@@ -7,9 +7,11 @@ supported_version = {
 }
 compat_version = supported_version.find { |requirement, version|
   Gem::Requirement.new(requirement).satisfied_by?(vagrant_version)
-}[1]
+}
 
-if !compat_version
+if compat_version
+  compat_version = compat_version[1]
+else
   # @TODO: yield warning
   compat_version = supported_version.to_a.last[1]
 end


### PR DESCRIPTION
If Vagrant version doesn't match anything in the `supported_version` hash, `find` returns `nil`.

I'm not very happy how the code looks, so suggestions to clean it up are happily accepted. =)
