### PR TITLE
Attempt to handle CentOS / RHEL outdated kernel

### DIFF
--- a/lib/vagrant-vbguest/installers/redhat.rb
+++ b/lib/vagrant-vbguest/installers/redhat.rb
@@ -1,6 +1,8 @@
 module VagrantVbguest
   module Installers
     class RedHat < Linux
+      include VagrantVbguest::Helpers::Rebootable
+
       # Scientific Linux (and probably CentOS) both show up as :redhat
       # fortunately they're probably both similar enough to RHEL
       # (RedHat Enterprise Linux) not to matter.
@@ -10,11 +12,26 @@ module VagrantVbguest
 
       # Install missing deps and yield up to regular linux installation
       def install(opts=nil, &block)
+        check_kernel(opts, &block)
         communicate.sudo(install_dependencies_cmd, opts, &block)
         super
       end
 
     protected
+      # on outdated CentOS Boxes, the kernel needs to be updated to install kernel-devel
+      def check_kernel(opts=nil, &block)
+        opts = {:error_check => false}.merge(opts || {})
+        exit_status = communicate.sudo("yum check-update kernel", opts, &block)
+        update_kernel(opts, &block) unless exit_status == 0
+      end
+
+      # update the kernel, then reboot and rerun VBGuest plugin
+      def update_kernel(opts=nil, &block)
+        communicate.sudo("yum install -y kernel", opts, &block)
+        opts = {:auto_reboot => true}.merge(opts || {})
+        #reboot(vm, opts)
+      end
+
       def install_dependencies_cmd
         "yum install -y #{dependencies}"
       end

--- a/lib/vagrant-vbguest/vagrant_compat/vagrant_1_1/rebootable.rb
+++ b/lib/vagrant-vbguest/vagrant_compat/vagrant_1_1/rebootable.rb
@@ -6,7 +6,7 @@ module VagrantVbguest
     module Rebootable
       def reboot(vm, options)
         if reboot? vm, options
-          simle_reboot = Vagrant::Action::Builder.new.tap do |b|
+          simple_reboot = Vagrant::Action::Builder.new.tap do |b|
             b.use Vagrant::Action::Builtin::Call, Vagrant::Action::Builtin::GracefulHalt, :poweroff, :running do |env2, b2|
               if !env2[:result]
                 b2.use VagrantPlugins::ProviderVirtualBox::Action::ForcedHalt
@@ -17,7 +17,7 @@ module VagrantVbguest
               b.use Vagrant::Action::Builtin::WaitForCommunicator, [:starting, :running]
             end
           end
-          @env[:action_runner].run(simle_reboot, @env)
+          @env[:action_runner].run(simple_reboot, @env)
         end
       end
 


### PR DESCRIPTION
I attempted to handle for the outdated kernel issue by checking to see if an update is available, performing the update and then rebooting. Unfortunately, I am far from being a Ruby dev and I couldn't get the reboot to work right on Vagrant 1.7.2 and MacOSX. So I just commented that out for now and a manual `vagrant reload` is required after the initial up. But this gets us closer to a solution for dotless-de/vagrant-vbguest#141.

Please offer any advice on improving the code I completed or getting the reboot to work.