### PR TITLE
add bzip2 to RHEL dependencies

### DIFF
--- a/lib/vagrant-vbguest/installers/redhat.rb
+++ b/lib/vagrant-vbguest/installers/redhat.rb
@@ -20,7 +20,7 @@ module VagrantVbguest
       end
 
       def dependencies
-        packages = ['kernel-devel-`uname -r`', 'gcc', 'make', 'perl']
+        packages = ['kernel-devel-`uname -r`', 'gcc', 'make', 'perl', 'bzip2']
         packages.join ' '
       end
     end


### PR DESCRIPTION
The official CentOS 7 vagrant box at https://vagrantcloud.com/centos/boxes/7 does not have bzip2 installed by default. When you use the vagrant-vbguest plugin on it, it will fail with the following error message:

```
Installing Virtualbox Guest Additions 4.3.28 - guest version is 
Verifying archive integrity... All good.
Uncompressing VirtualBox 4.3.28 Guest Additions for Linux............
VirtualBox Guest Additions installer
Please install the bzip2 utility.
Copying additional installer modules ...
./install.sh: line 344: bzip2: command not found
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
./install.sh: line 357: bzip2: command not found
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
An error occurred during installation of VirtualBox Guest Additions 4.3.28. Some functionality may not work as intended.
In most cases it is OK that the "Window System drivers" installation failed.
```

This pull requests simply makes sure bzip2 is installed on RHEL boxes.