### PR TITLE
Add 'force' argument to VBoxLinuxAdditions.run

### DIFF
--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -121,7 +121,7 @@ module VagrantVbguest
       # The absolute path to the GuestAdditions installer script.
       # The iso file has to be mounted on +mount_point+.
       def installer
-        @installer ||= File.join(mount_point, 'VBoxLinuxAdditions.run')
+        @installer ||= File.join(mount_point, 'VBoxLinuxAdditions.run force')
       end
 
       # The arguments string, which gets passed to the installer script


### PR DESCRIPTION
When using CentOS 7, the VBoxLinuxAdditions.run fails claiming incorrectly it is already installed from another source:

```
Installing Virtualbox Guest Additions 4.3.28 - guest version is
Verifying archive integrity... All good.
Uncompressing VirtualBox 4.3.28 Guest Additions for Linux............
VirtualBox Guest Additions installer
You appear to have a version of the VBoxGuestAdditions software
on your system which was installed from a different source or using a
different type of installer.  If you installed it from a package from your
Linux distribution or if it is a default part of the system then we strongly
recommend that you cancel this installation and remove it properly before
installing this version.  If this is simply an older or a damaged
installation you may safely proceed.

Do you wish to continue anyway? [yes or no]

Cancelling installation.
```

Adding a "force" argument to the VBoxLinuxAdditions.run command line is a functional, if brute-force workaround.