### PR TITLE
Check for debian8 in debian installer

### DIFF
--- a/lib/vagrant-vbguest/installers/debian.rb
+++ b/lib/vagrant-vbguest/installers/debian.rb
@@ -3,7 +3,7 @@ module VagrantVbguest
     class Debian < Linux
 
       def self.match?(vm)
-        :debian == self.distro(vm)
+        [:debian, :debian8].include? self.distro(vm)
       end
 
       # installes the correct linux-headers package


### PR DESCRIPTION
For Debian 8 boxes, the vagrant guest name is `debian8`, not just `debian`.