### PR TITLE
Update debian.rb

### DIFF
--- a/lib/vagrant-vbguest/installers/debian.rb
+++ b/lib/vagrant-vbguest/installers/debian.rb
@@ -24,7 +24,7 @@ module VagrantVbguest
 
     protected
       def install_dependencies_cmd
-        "apt-get install -y #{dependencies}"
+        "apt-get install -y --force-yes #{dependencies}"
       end
 
       def dependencies


### PR DESCRIPTION
Adding the force-yes flag, the install was failing with the 'dkms' package, as it requires the --force-yes flag.
