### PR TITLE
Fedora 22 & 23 fail: 'which' not installed

### DIFF
--- a/lib/vagrant-vbguest/installers/fedora.rb
+++ b/lib/vagrant-vbguest/installers/fedora.rb
@@ -15,7 +15,7 @@ module VagrantVbguest
       protected
 
       def install_dependencies_cmd
-        "`which dnf || which yum` install -y #{dependencies}"
+        "`bash -c 'type -p dnf || type -p yum'` install -y #{dependencies}"
       end
 
       def dependencies


### PR DESCRIPTION
Here's a more robust version of detecting dnf or yum, which doesn't rely on `which`.