### PR TITLE
opensuse should install based on the patterns

### DIFF
--- a/lib/vagrant-vbguest/installers/opensuse.rb
+++ b/lib/vagrant-vbguest/installers/opensuse.rb
@@ -19,11 +19,11 @@ module VagrantVbguest
       end
 
       def install_dependencies_cmd
-        "zypper --non-interactive install #{dependencies}"
+        "zypper --non-interactive install -t pattern #{dependencies}"
       end
 
       def dependencies
-        packages = ['kernel-devel', 'gcc', 'make', 'tar']
+        packages = ['devel_C_C++', 'devel_basis', 'devel_kernel']
         packages.join ' '
       end
     end


### PR DESCRIPTION
There is no kernel-devel on opensuse. Instead we use the zypper "patterns". I added some patterns, that maybe are more than the necessary. However it works as expected. 