### PR TITLE
removes version-specific package name

### DIFF
--- a/lib/vagrant-vbguest/installers/redhat.rb
+++ b/lib/vagrant-vbguest/installers/redhat.rb
@@ -21,7 +21,7 @@ module VagrantVbguest
 
       def dependencies
         packages = [
-          'kernel-devel-`uname -r`', 'gcc', 'binutils', 'make', 'perl', 'bzip2'
+          'kernel-devel', 'gcc', 'binutils', 'make', 'perl', 'bzip2'
         ]
         packages.join ' '
       end


### PR DESCRIPTION
removes version-specific package name as redHat/CentOS standard repos only have "kernel-devel" as package name
