### PR TITLE
Support for new ENV Variable VBOX_MSI_INSTALL_PATH

### DIFF
--- a/lib/vagrant-vbguest/hosts/virtualbox.rb
+++ b/lib/vagrant-vbguest/hosts/virtualbox.rb
@@ -87,7 +87,7 @@ module VagrantVbguest
         # Makes an educated guess where the GuestAdditions iso file
         # on windows systems
         def windows_path
-          if (p = ENV["VBOX_INSTALL_PATH"]) && !p.empty?
+          if (p = ENV["VBOX_INSTALL_PATH"] || ENV["VBOX_MSI_INSTALL_PATH"]) && !p.empty?
             File.join(p, "VBoxGuestAdditions.iso")
           elsif (p = ENV["PROGRAM_FILES"] || ENV["ProgramW6432"] || ENV["PROGRAMFILES"]) && !p.empty?
             File.join(p, "/Oracle/VirtualBox/VBoxGuestAdditions.iso")


### PR DESCRIPTION
Added support for emvironement variable VBOX_MSI_INSTALL_PATH which gets set on newer versions of Virtual Box instead of VBOX_INSTALL_PATH. This way, the plugin will find the VBoxGuestAdditions.iso which comes with the installation of never virtual box versions again.
closes #205