### PR TITLE
Fixed: File.unlink exception on Windows

### DIFF
--- a/lib/vagrant-vbguest/download.rb
+++ b/lib/vagrant-vbguest/download.rb
@@ -23,8 +23,13 @@ module VagrantVbguest
         # Unlinking the downloaded file might crash on Windows
         # see: https://github.com/dotless-de/vagrant-vbguest/issues/189
         begin
+          # Even if delete failed on Windows, we still can clean this file to save disk space
+          File.open(destination,'wb') do |f|
+            f.write('')
+            f.close()
+          end
           File.unlink(destination)
-        rescue Error => e
+        rescue Errno::EACCES => e
           @ui.warn I18n.t("vagrant_vbguest.download.cleaning_failed", message: e.message, destination: destination)
         end
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -62,5 +62,5 @@ en:
       cleaning: "Cleaning up downloaded VirtualBox Guest Additions ISO..."
       cleaning_failed: |-
         FAILED: %{message}
-        You might want to delete this file mauanlly: %{destination}
+        You might want to delete this file manually: %{destination}
       unknown_type: "Unknown or unsupported URI type given for VirtualBox Guest Additions ISO download."

--- a/vagrant-vbguest.gemspec
+++ b/vagrant-vbguest.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|testdrive)/}) }
   s.bindir        = "exe"
-  s.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
 end


### PR DESCRIPTION
And some other typo mistakes

Fixed: https://github.com/dotless-de/vagrant-vbguest/issues/189