### PR TITLE
ADD: install dkms if available (for example epel provides)

### DIFF
--- a/lib/vagrant-vbguest/installers/redhat.rb
+++ b/lib/vagrant-vbguest/installers/redhat.rb
@@ -21,7 +21,7 @@ module VagrantVbguest
 
       def dependencies
         packages = [
-          'kernel-devel-`uname -r`', 'gcc', 'binutils', 'make', 'perl', 'bzip2'
+          'kernel-devel-`uname -r`', 'gcc', 'binutils', 'make', 'perl', 'bzip2', 'dkms'
         ]
         packages.join ' '
       end


### PR DESCRIPTION
Install dkms (Dynamic Kernel Module Support) on RHEL/CentOS/"etc" distros if available to simplify kernel upgrades.  As 'yum install -y' is used, if the package is not found that shouldn't cause a problem either.

EPEL (epel-release) provides dkms for CentOS6/7 and RHEL7 among others.  However I'm not sure we want to take it upon ourselves to install/enable EPEL, certainly not by default.

