### PR TITLE
Overloaded == was removed in micromachine 2.0.0

### DIFF
--- a/lib/vagrant-vbguest/machine.rb
+++ b/lib/vagrant-vbguest/machine.rb
@@ -45,9 +45,9 @@ module VagrantVbguest
       guest_additions_state.trigger :start
     end
 
-    def installation_ran?; guest_additions_state == :installed end
-    def started?; guest_additions_state == :started end
-    def rebuilt?; guest_additions_state == :rebuilt end
+    def installation_ran?; guest_additions_state.state == :installed end
+    def started?; guest_additions_state.state == :started end
+    def rebuilt?; guest_additions_state.state == :rebuilt end
 
     def reboot;  box_state.trigger :reboot end
     def reboot?; box_state.state == :rebooted end


### PR DESCRIPTION
Commit [b679d5a](https://github.com/soveran/micromachine/commit/b679d5ae52909bc0cfae341b6a4e12f95da41555#diff-25e7e2ab2cecabe612c9d1a001bc992eL54l) in soveran/micromachine removed the overloaded == operator for state machines.  I ran into this with some vagrant boxes that required a reboot after upgrading virtual box tools.  Because == now compares the state machine object to a string, [installation_ran? in machine.rb](https://github.com/dotless-de/vagrant-vbguest/blob/v0.12.0/lib/vagrant-vbguest/machine.rb#L48) always returns false.  So instead of running the reboot state (see [machine.rb L60](https://github.com/dotless-de/vagrant-vbguest/blob/v0.12.0/lib/vagrant-vbguest/machine.rb#L60)), vbguest fails with a loop detected since it proceeds to start instead:

    vagrant_vbguest.machine_loop_guard

We end up having to manually reboot our virtual machines to get the tools loaded correctly now, so this it a fairly annoying issue.

To simulate a machine that needs reboot after installing the tools, you can remove the ! in:

https://github.com/dotless-de/vagrant-vbguest/blob/v0.12.0/lib/vagrant-vbguest/machine.rb#L74