### PR TITLE
add archlinux installer

### DIFF
--- a/lib/vagrant-vbguest.rb
+++ b/lib/vagrant-vbguest.rb
@@ -25,6 +25,7 @@ require 'vagrant-vbguest/installers/redhat'
 require 'vagrant-vbguest/installers/oracle'
 require 'vagrant-vbguest/installers/fedora'
 require 'vagrant-vbguest/installers/opensuse'
+require 'vagrant-vbguest/installers/archlinux'
 
 require 'vagrant-vbguest/middleware'
 

--- a/lib/vagrant-vbguest/installers/archlinux.rb
+++ b/lib/vagrant-vbguest/installers/archlinux.rb
@@ -1,0 +1,30 @@
+module VagrantVbguest
+  module Installers
+    class Archlinux < Linux
+
+      def self.match?(vm)
+        :arch == self.distro(vm)
+      end
+
+      # Install missing deps and yield up to regular linux installation
+      def install(opts=nil, &block)
+        # Update the package list
+        communicate.sudo("pacman -Sy", opts, &block)
+        # Install the dependencies
+        communicate.sudo(install_dependencies_cmd, opts, &block)
+        super
+      end
+
+      protected
+      def install_dependencies_cmd
+        "pacman -S #{dependencies} --noconfirm --needed"
+      end
+
+      def dependencies
+        packages = ['gcc', 'dkms', 'make', 'bzip2']
+        packages.join ' '
+      end
+    end
+  end
+end
+VagrantVbguest::Installer.register(VagrantVbguest::Installers::Archlinux, 5)

--- a/lib/vagrant-vbguest/installers/debian.rb
+++ b/lib/vagrant-vbguest/installers/debian.rb
@@ -6,9 +6,9 @@ module VagrantVbguest
         /\Adebian\d*\Z/ =~ self.distro(vm)
       end
 
-      # installes the correct linux-headers package
-      # installes `dkms` package for dynamic kernel module loading
-      # @param opts [Hash] Optional options Hash wich meight get passed to {Vagrant::Communication::SSH#execute} and firends
+      # installs the correct linux-headers package
+      # installs `dkms` package for dynamic kernel module loading
+      # @param opts [Hash] Optional options Hash which might get passed to {Vagrant::Communication::SSH#execute} and friends
       # @yield [type, data] Takes a Block like {Vagrant::Communication::Base#execute} for realtime output of the command being executed
       # @yieldparam [String] type Type of the output, `:stdout`, `:stderr`, etc.
       # @yieldparam [String] data Data for the given output.
@@ -29,7 +29,7 @@ module VagrantVbguest
 
       def dependencies
         packages = ['linux-headers-`uname -r`']
-        # some Debian system (lenny) dont come with a dkms packe so we neet to skip that.
+        # some Debian system (lenny) don't come with a dkms package so we need to skip that.
         # apt-cache search will exit with 0 even if nothing was found, so we need to grep.
         packages << 'dkms' if communicate.test('apt-cache search --names-only \'^dkms$\' | grep dkms')
         packages.join ' '

--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -12,8 +12,8 @@ module VagrantVbguest
       # @see {Vagrant::Guest::Linux#distro_dispatch}
       # @return [Symbol] One of `:debian`, `:ubuntu`, `:gentoo`, `:fedora`, `:redhat`, `:suse`, `:arch`
       def self.distro(vm)
-        @@ditro ||= {}
-        @@ditro[ vm_id(vm) ] ||= distro_name vm
+        @@distro ||= {}
+        @@distro[ vm_id(vm) ] ||= distro_name vm
       end
 
       # Matches if the operating system name prints "Linux"


### PR DESCRIPTION
Add an Archlinux installer

I left out installing linux-headers as a dependency because you can't get the older headers that match the running kernel if they are not already installed (which they often are) because Arch is rolling release, so you'd have to do a full system upgrade which would require another reboot before compiling the VirtualBox Guest Additions kernel modules. Also because the latest 4.6.4-1 kernel-headers don't seem to work with vbguest 5.0.8 (the one I tested with) I think it's better to just assume that kernel-headers are installed.
```
/var/lib/dkms/vboxguest/5.0.8/build/vboxguest/r0drv/linux/memobj-r0drv-linux.c:1032:14: error: too many arguments to function ‘get_user_pages’
         rc = get_user_pages(pTask,                  /* Task for fault accounting. */
              ^~~~~~~~~~~~~~
In file included from /var/lib/dkms/vboxguest/5.0.8/build/vboxguest/r0drv/linux/the-linux-kernel.h:88:0,
...
```
seems to be related to [this](https://github.com/torvalds/linux/commit/d4edcf0d56958db0aca0196314ca38a5e730ea92)


I tested on an Ubuntu 14.04.4 LTS host with Vagrant 1.8.5 using [this basebox](https://github.com/terrywang/vagrantboxes/blob/master/archlinux-x86_64.md) which has ```linux-headers 4.2.5-1``` installed and my Vagrantfile looked like this:
```
Vagrant.configure('2') do |config|
        config.vm.box = "archlinux_x86_64"
        config.vm.box_url = "http://cloud.terry.im/vagrant/archlinux-x86_64.box"
        config.vm.provision "shell", inline: "pacman -Rsc virtualbox-guest-dkms --noconfirm"
end
```

Running Vagrant up will result in a situation where the guest additions are already installed. 

```
[default] GuestAdditions 5.0.8 running --- OK.
```

After removing the guest additions and reloading:
```
root@archlinux:/home/vagrant# pacman -Q | grep virtualbox | awk '{print$1}' | xargs pacman -Rsc --noconfirm
$ vagrant reload
```

The guest additions will be built and installed
```
==> default: Machine booted and ready!
[default] GuestAdditions versions on your host (5.0.8) and guest (5.0.2) do not match.
:: Synchronizing package databases...
downloading core.db...
downloading extra.db...
downloading community.db...
downloading archlinuxfr.db...
resolving dependencies...
warning: bzip2-1.0.6-5 is up to date -- skipping
looking for conflicting packages...

Packages (7) binutils-2.26.1-2  gcc-libs-6.1.1-4  glibc-2.24-1  linux-api-headers-4.7-1  dkms-2.2.0.3+git151023-12  gcc-6.1.1-4  make-4.2.1-1

Total Download Size:    56.81 MiB
Total Installed Size:  257.78 MiB
Net Upgrade Size:       54.06 MiB
...
installing dkms...
Optional dependencies for dkms
    linux-headers: build modules against the Arch kernel [installed]
    linux-lts-headers: build modules against the LTS kernel
    linux-zen-headers: build modules against the ZEN kernel
    linux-grsec-headers: build modules against the GRSEC kernel
Copy iso file /usr/share/virtualbox/VBoxGuestAdditions.iso into the box /tmp/VBoxGuestAdditions.iso
mount: /dev/loop0 is write-protected, mounting read-only
Installing Virtualbox Guest Additions 5.0.8 - guest version is 5.0.2
Verifying archive integrity... All good.
Uncompressing VirtualBox 5.0.8 Guest Additions for Linux............
VirtualBox Guest Additions installer
Copying additional installer modules ...
add_symlink: link file /usr/lib/VBoxGuestAdditions already exists
Installing additional modules ...
Removing existing VirtualBox DKMS kernel modules ...done.
Removing existing VirtualBox non-DKMS kernel modules ...done.
Building the VirtualBox Guest Additions kernel modules ...done.
Doing non-kernel setup of the Guest Additions ...done.
Starting the VirtualBox Guest Additions ...done.
```

Reloading again after installing built Guest Additions:
```
[default] GuestAdditions 5.0.8 running --- OK.
```
