### PR TITLE
Add a specific CentOS installer

### DIFF
--- a/lib/vagrant-vbguest.rb
+++ b/lib/vagrant-vbguest.rb
@@ -21,14 +21,16 @@ require 'vagrant-vbguest/hosts/virtualbox'
 require 'vagrant-vbguest/installer'
 require 'vagrant-vbguest/installers/base'
 require 'vagrant-vbguest/installers/linux'
+
+require 'vagrant-vbguest/installers/archlinux'
 require 'vagrant-vbguest/installers/debian'
 require 'vagrant-vbguest/installers/ubuntu'
 require 'vagrant-vbguest/installers/redhat'
 require 'vagrant-vbguest/installers/oracle'
+require 'vagrant-vbguest/installers/centos'
 require 'vagrant-vbguest/installers/fedora'
 require 'vagrant-vbguest/installers/opensuse'
 require 'vagrant-vbguest/installers/suse'
-require 'vagrant-vbguest/installers/archlinux'
 
 require 'vagrant-vbguest/middleware'
 

--- a/lib/vagrant-vbguest/installers/centos.rb
+++ b/lib/vagrant-vbguest/installers/centos.rb
@@ -1,0 +1,50 @@
+module VagrantVbguest
+  module Installers
+    class CentOS < Linux
+      # Scientific Linux and CentOS show up as :redhat (or "centos7")
+      # fortunately they're probably both similar enough to RHEL
+      # (RedHat Enterprise Linux) not to matter.
+      def self.match?(vm)
+        /\A(centos)\d*\Z/ =~ self.distro(vm) ||
+          communicate_to(vm).test('test -f /etc/centos-release')
+      end
+
+      # Install missing deps and yield up to regular linux installation
+      def install(opts=nil, &block)
+        communicate.sudo(install_dependencies_cmd, opts, &block)
+        install_kernel_dependencies!(opts, &block)
+        super
+      end
+
+    protected
+      def install_dependencies_cmd
+        "yum install -y #{dependencies}"
+      end
+
+      def dependencies
+        "gcc binutils make perl bzip2"
+      end
+
+      def install_kernel_dependencies!(opts=nil, &block)
+        install_args = [
+          'kernel-devel-`uname -r`',
+
+          '--enablerepo=C`grep -oP \'\d+\.\d+\' /etc/centos-release`-base '\
+            '--enablerepo=C`grep -oP \'\d+\.\d+\' /etc/centos-release`-updates kernel-devel',
+
+          '--enablerepo=C*-base --enablerepo=C*-updates kernel-devel',
+        ]
+
+        begin
+          return false if install_args.empty?
+
+          cmd = "yum install -y #{install_args.shift}"
+          communicate.sudo(cmd, opts, &block)
+        rescue
+          retry
+        end
+      end
+    end
+  end
+end
+VagrantVbguest::Installer.register(VagrantVbguest::Installers::CentOS, 6)

--- a/lib/vagrant-vbguest/installers/redhat.rb
+++ b/lib/vagrant-vbguest/installers/redhat.rb
@@ -5,7 +5,7 @@ module VagrantVbguest
       # fortunately they're probably both similar enough to RHEL
       # (RedHat Enterprise Linux) not to matter.
       def self.match?(vm)
-        /\A(redhat|centos)\d*\Z/ =~ self.distro(vm)
+        :redhat == self.distro(vm)
       end
 
       # Install missing deps and yield up to regular linux installation

--- a/testdrive/Vagrantfile
+++ b/testdrive/Vagrantfile
@@ -54,6 +54,9 @@ Vagrant.configure("2") do |config|
   next_ip.box config, "opensuse13", "bento/opensuse-13.2"
   next_ip.box config, "suse12", "elastic/sles-12-x86_64"
   next_ip.box config, "ubuntu1404", "ubuntu/trusty64"
+  next_ip.box config, "centos65", "box-cutter/centos65" do |cfg|
+    cfg.vm.box_version = "2.0.10"
+  end
   next_ip.box config, "centos7", "centos/7"
   next_ip.box config, "oracle65", "tobyhferguson_oracle-65-x64" do |cfg|
     cfg.vm.box_url = "http://tobyhferguson.org/boxes/oracle-6-5-x64-virtualbox.box"


### PR DESCRIPTION
Which tries to “Handle CentOS outdated kernel using CentOS's 'vault' repository” as described in #223.

Sadly, this still seems to not really work for VirtualBox (complaining about mismatching kernel headers):

```
Resolving Dependencies
--> Running transaction check
---> Package kernel-devel.x86_64 0:2.6.32-642.3.1.el6 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package            Arch         Version                    Repository     Size
================================================================================
Installing:
 kernel-devel       x86_64       2.6.32-642.3.1.el6         updates        11 M

Transaction Summary
================================================================================
Install       1 Package(s)

Total download size: 11 M
Installed size: 26 M
Downloading Packages:
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Installing : kernel-devel-2.6.32-642.3.1.el6.x86_64                       1/1
  Verifying  : kernel-devel-2.6.32-642.3.1.el6.x86_64                       1/1

Installed:
  kernel-devel.x86_64 0:2.6.32-642.3.1.el6

...

Building the VirtualBox Guest Additions kernel modules
The headers for the current running kernel were not found. If the following
module compilation fails then this could be the reason.
The missing package can be probably installed with
yum install kernel-devel-2.6.32-431.el6.x86_64

Building the main Guest Additions module[FAILED]
```
