### PR TITLE
Fix yield_installation_waring name

### DIFF
--- a/lib/vagrant-vbguest/installers/base.rb
+++ b/lib/vagrant-vbguest/installers/base.rb
@@ -143,7 +143,7 @@ module VagrantVbguest
       # Helper to yield a warning message to the user, that the installation
       # will start _now_.
       # The message includes the host and installer version strings.
-      def yield_installation_waring(path_to_installer)
+      def yield_installation_warning(path_to_installer)
         @env.ui.warn I18n.t("vagrant_vbguest.installing#{@options[:force] ? '_forced' : ''}",
           :guest_version     => (guest_version || I18n.t("vagrant_vbguest.unknown")),
           :installer_version => installer_version(path_to_installer) || I18n.t("vagrant_vbguest.unknown"))

--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -207,7 +207,7 @@ module VagrantVbguest
       # @yieldparam [String] type Type of the output, `:stdout`, `:stderr`, etc.
       # @yieldparam [String] data Data for the given output.
       def execute_installer(opts=nil, &block)
-        yield_installation_waring(installer)
+        yield_installation_warning(installer)
         opts = {:error_check => false}.merge(opts || {})
         exit_status = communicate.sudo("#{installer} #{installer_arguments}", opts, &block)
         yield_installation_error_warning(installer) unless exit_status == 0


### PR DESCRIPTION
### This PR does the following:
- Replaces all occurrences of `yield_installation_waring` with `yield_installation_warning`.
