### PR TITLE
Add synopsis for help/list-commands (fixes #235)

### DIFF
--- a/lib/vagrant-vbguest/vagrant_compat/vagrant_1_1/command.rb
+++ b/lib/vagrant-vbguest/vagrant_compat/vagrant_1_1/command.rb
@@ -7,6 +7,11 @@ module VagrantVbguest
     include CommandCommons
     include VagrantPlugins::CommandUp::StartMixins
 
+    # Show description when `vagrant list-commands` is triggered
+    def self.synopsis
+      "plugin: vagrant-vbguest: install VirtualBox Guest Additions to the machine"
+    end 
+
     def check_runable_on(vm)
       raise Vagrant::Errors::VMNotCreatedError if vm.state.id == :not_created
       raise Vagrant::Errors::VMInaccessible if vm.state.id == :inaccessible


### PR DESCRIPTION
### This PR does the following:

* Adds code necessary to display synopsis for `vagrant --help` and `vagrant list-commands`.

### Fixes issue:

* #235 

### Testing

* Ran `bundle exec vagrant`.
* Manual test of local plugin installation.
