### PR TITLE
Add logging of mount location

### DIFF
--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -230,6 +230,7 @@ module VagrantVbguest
       # @yieldparam [String] type Type of the output, `:stdout`, `:stderr`, etc.
       # @yieldparam [String] data Data for the given output.
       def mount_iso(opts=nil, &block)
+        env.ui.info(I18n.t("vagrant_vbguest.mounting_iso", :mount_point => mount_point))
         communicate.sudo("mount #{tmp_path} -o loop #{mount_point}", opts, &block)
       end
 
@@ -242,6 +243,7 @@ module VagrantVbguest
       # @yieldparam [String] type Type of the output, `:stdout`, `:stderr`, etc.
       # @yieldparam [String] data Data for the given output.
       def unmount_iso(opts=nil, &block)
+        env.ui.info(I18n.t("vagrant_vbguest.unmounting_iso", :mount_point => mount_point))
         communicate.sudo("umount #{mount_point}", opts, &block)
       end
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,6 +2,8 @@ en:
   vagrant_vbguest:
     skipped_installation: "Updating GuestAdditions skipped."
     skipped_rebuild: "Rebuilding GuestAdditions skipped."
+    mounting_iso: "Mounting Virtualbox Guest Additions ISO to: %{mount_point}"
+    unmounting_iso: "Unmounting Virtualbox Guest Additions ISO from: %{mount_point}"
     installing: "Installing Virtualbox Guest Additions %{installer_version} - guest version is %{guest_version}"
     installing_forced: "Forcing installation of Virtualbox Guest Additions %{installer_version} - guest version is %{guest_version}"
     rebuild: "Rebuilding Virtualbox Guest Additions %{guest_version} (Your host version is %{host_version})"


### PR DESCRIPTION
### This PR does the following:
- Adds code necessary to display the mount point used, which adds more reporting of progress and debugging information for the user.
- Adds functionality which will be useful to have for vagrant-vbguest extension plugins to utilize, for OSes where the mount point might be less predictable than in OSes currently supported by vbguest.
### Fixes issue:
- None
### Testing
- Manual test of local plugin installation.
- Ran `vagrant up` and verified new functionality against an Ubuntu image.