### PR TITLE
Support a no-options install in the Debian Installer (fixes #255)

### DIFF
--- a/lib/vagrant-vbguest/installers/debian.rb
+++ b/lib/vagrant-vbguest/installers/debian.rb
@@ -16,7 +16,7 @@ module VagrantVbguest
         begin
           communicate.sudo(install_dependencies_cmd, opts, &block)
         rescue
-          communicate.sudo('apt-get -y --force-yes update', opts.merge(:error_check => false), &block)
+          communicate.sudo('apt-get -y --force-yes update', (opts || {}).merge(:error_check => false), &block)
           communicate.sudo(install_dependencies_cmd, opts, &block)
         end
         super


### PR DESCRIPTION
Fixes #255 (Debian Installer throws "undefined method `merge' for nil:NilClass").

The issue appears to have been introduced by 1ec80596afdaefad15f399a1eb29d000055e3e13, so it probably affected both v0.14.0 and v0.14.1. This handling logic already exists [over in `ubuntu.rb`](https://github.com/dotless-de/vagrant-vbguest/blob/daf3cf8cc1604740277925f34d1398e6d0c386a3/lib/vagrant-vbguest/installers/ubuntu.rb#L29), I'm just applying it to the Debian installer here.