### PR TITLE
Fix `yes` option behaviour so that it works

### DIFF
--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -223,12 +223,13 @@ module VagrantVbguest
 
       # Determine if yes needs to be called or not
       def yes
-        # Simple yes if explicity boolean true
-        return "yes | " if !!@yes == @yes && @yes
+        value = @options[:yes]
+        # Simple yes if explicitly boolean true
+        return "yes | " if !!value == value && value
         # Nothing if set to false
-        return "" if !@yes
+        return "" if !value
         # Otherwise pass input string to yes
-        "yes @#{yes} | "
+        "yes #{value} | "
       end
 
       # A generic helper method for mounting the GuestAdditions iso file


### PR DESCRIPTION
After noticing that https://github.com/dotless-de/vagrant-vbguest/commit/e8006b285978c8a64d12eb2e5ac14b915c51115f introduced the `yes` configuration option (eg the yes-to-everything setting which defaults to `true`), I continued to experience #252, where installation was still being cancelled. 

Looking into this further, I noticed that the `yes` function on the installer class was looking up the `@yes` instance variable (`nil` as it doesn't exist) rather than `@options[:yes]` where the option actually is.

This PR looks up the right spot and fixes a minor typo in the comment.