### PR TITLE
(GH-298) Fix bug on EL7 where shared folders would not work

### DIFF
--- a/lib/vagrant-vbguest/installers/redhat.rb
+++ b/lib/vagrant-vbguest/installers/redhat.rb
@@ -21,7 +21,7 @@ module VagrantVbguest
 
       def dependencies
         packages = [
-          'kernel-devel-`uname -r`', 'gcc', 'binutils', 'make', 'perl', 'bzip2'
+          'kernel-devel', 'kernel-devel-`uname -r`', 'gcc', 'binutils', 'make', 'perl', 'bzip2'
         ]
         packages.join ' '
       end


### PR DESCRIPTION
This patch adds the kernel-devel package to the list of dependencies.
This keeps previous behavior of installing kernel-devel-`uname -r` while
also installing kernel-devel. If a package is not found, yum will
continue to install the packages it does find, so there is no issue with
essentially listing it twice.