### PR TITLE
Update the clean status message.

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -27,7 +27,7 @@ en:
     unknown: unknown
 
     status:
-      clean: "[%{vm_name}] No installation found."
+      clean: "[%{vm_name}] No Virtualbox Guest Additions installation found."
       unmatched: "[%{vm_name}] GuestAdditions versions on your host (%{host_version}) and guest (%{guest_version}) do not match."
       not_running: "[%{vm_name}] GuestAdditions seems to be installed (%{guest_version}) correctly, but not running."
       ok: "[%{vm_name}] GuestAdditions %{guest_version} running --- OK."


### PR DESCRIPTION
The `vagrant_vbguest.status.clean` message, "No installation found", is ambiguous and it doesn't give enough context.

```
...
==> main-machine: Waiting for machine to boot. This may take a few minutes...
    main-machine: SSH address: 127.0.0.1:2200
    main-machine: SSH username: vagrant
    main-machine: SSH auth method: private key
    main-machine: 
    main-machine: Vagrant insecure key detected. Vagrant will automatically replace
    main-machine: this with a newly generated keypair for better security.
    main-machine: 
    main-machine: Inserting generated public key within guest...
    main-machine: Removing insecure key from the guest if it's present...
    main-machine: Key inserted! Disconnecting and reconnecting using new SSH key...
==> main-machine: Machine booted and ready!
[main-machine] No installation found.
Loaded plugins: fastestmirror
Determining fastest mirrors
...
```
