### PR TITLE
centos 6 doesn't have three components in its version number

### DIFF
--- a/lib/vagrant-vbguest/installers/centos.rb
+++ b/lib/vagrant-vbguest/installers/centos.rb
@@ -31,7 +31,7 @@ module VagrantVbguest
       def release_version
         release = nil
         communicate.sudo('cat /etc/centos-release') do |type, data|
-          release = data.to_s[/(\d+\.\d+\.\d+)/, 1]
+          release = data.to_s[/(\d+\.\d+(\.\d+)?)/, 1]
         end
         release
       end


### PR DESCRIPTION
I was able to test this on a CentOS 6 and a CentOS 7 box successfully but only with Vagrant 2.2.3.