### PR TITLE
Fix for virtualbox 6.0.6

### DIFF
--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -179,7 +179,8 @@ module VagrantVbguest
           "/lib64/VBoxGuestAdditions/#{tool}",
           "/lib/VBoxGuestAdditions/#{tool}",
           "/etc/init.d/#{tool}",
-          "/usr/sbin/rc#{tool}"
+          "/usr/sbin/rc#{tool}",
+          "/sbin/rc#{tool}"
         ]
         cmd = <<-SHELL
         for c in #{candidates.join(" ")}; do

--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -78,7 +78,7 @@ module VagrantVbguest
         opts = {
           :sudo => true
         }.merge(opts || {})
-        communicate.test('lsmod | grep vboxsf', opts, &block)
+        communicate.test('lsmod | grep vboxguest && test -e /lib/modules/`uname -r`/misc/vboxsf.ko', opts, &block)
       end
 
       # This overrides {VagrantVbguest::Installers::Base#guest_version}

--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -179,6 +179,7 @@ module VagrantVbguest
           "/lib64/VBoxGuestAdditions/#{tool}",
           "/lib/VBoxGuestAdditions/#{tool}",
           "/etc/init.d/#{tool}",
+          "/usr/sbin/rc#{tool}"
         ]
         cmd = <<-SHELL
         for c in #{candidates.join(" ")}; do

--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -78,7 +78,7 @@ module VagrantVbguest
         opts = {
           :sudo => true
         }.merge(opts || {})
-        communicate.test('lsmod | grep vboxguest && test -e /lib/modules/`uname -r`/misc/vboxsf.ko', opts, &block)
+        communicate.test('grep -qE "^vboxguest\s.+\s\([^\s]*O[^\s]*\)$" /proc/modules && test -e /lib/modules/`uname -r`/misc/vboxsf.ko', opts, &block)
       end
 
       # This overrides {VagrantVbguest::Installers::Base#guest_version}


### PR DESCRIPTION
Fixes for the breakage that happened with version 6.0.6, as discussed in https://github.com/dotless-de/vagrant-vbguest/issues/333.