### PR TITLE
Package elfutils-libelf-devel is required for RHEL 8

### DIFF
--- a/lib/vagrant-vbguest/installers/redhat.rb
+++ b/lib/vagrant-vbguest/installers/redhat.rb
@@ -27,7 +27,8 @@ module VagrantVbguest
           'binutils',
           'make',
           'perl',
-          'bzip2'
+          'bzip2',
+          'elfutils-libelf-devel'
         ].join(' ')
       end
     end


### PR DESCRIPTION
When using the plugin on a RHEL 8 box if fails with the following error seen in the log file:
```
Building the main Guest Additions module for kernel 4.18.0-80.el8.x86_64.
Error building the module.  Build output follows.
make V=1 CONFIG_MODULE_SIG= -C /lib/modules/4.18.0-80.el8.x86_64/build M=/tmp/vbox.0 SRCROOT=/tmp/vbox.0 -j1 modules
Makefile:958: *** "Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y, please install libelf-dev, libelf-devel or elfutils-libelf-devel".  Stop.
make: *** [/tmp/vbox.0/Makefile-footer.gmk:107: vboxguest] Error 2
Could not find the X.Org or XFree86 Window System, skipping.
```

To make this work the package `elfutils-libelf-devel` is required to be installed.

This PR addresses this and I have tested this only on RHEL 7 and 8