### PR TITLE
dependency on micromachine changed to 3.0

### DIFF
--- a/vagrant-vbguest.gemspec
+++ b/vagrant-vbguest.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "micromachine", "~> 2.0.0"
+  s.add_dependency "micromachine", "~> 3.0"
 
   # those should be satisfied by vagrant
   s.add_dependency "i18n"


### PR DESCRIPTION
micromachine is at 3.0.0 for quite some time...

>  3.0.0 - August 20, 2017 (9.5 KB) 
[https://rubygems.org/gems/micromachine](https://rubygems.org/gems/micromachine)