### PR TITLE
Set web_path endpoint to utilise HTTPS

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ end
 * `iso_path` : The full path or URL to the VBoxGuestAdditions.iso file. <br/>
 The `iso_path` may contain the optional placeholder `%{version}` replaced with detected VirtualBox version (e.g. `4.1.8`).
 Relative paths are tricky, try to use an absolute path where possible. If not, the path is relative to the current working directory, that is where the `vagrant` command is issued. You can make sure to always be relative to the `Vagrantfile` with a little bit of ruby: `File.expand_path("../relative/path/to/VBoxGuestAdditions.iso", __FILE__)`
-The default URI for the actual iso download is: `http://download.virtualbox.org/virtualbox/%{version}/VBoxGuestAdditions_%{version}.iso`<br/>
+The default URI for the actual iso download is: `https://download.virtualbox.org/virtualbox/%{version}/VBoxGuestAdditions_%{version}.iso`<br/>
 vbguest will try to autodetect the best option for your system. WTF? see below.
 * `iso_upload_path` (String, default: `/tmp`): A writeable directory where to put the VBoxGuestAdditions.iso file on the guest system.
 * `iso_mount_point` (String, default: `/mnt`): Where to mount the VBoxGuestAdditions.iso file on the guest system.

--- a/lib/vagrant-vbguest/hosts/virtualbox.rb
+++ b/lib/vagrant-vbguest/hosts/virtualbox.rb
@@ -36,7 +36,7 @@ module VagrantVbguest
         #
         # @return [String] A URI template containing the versions placeholder.
         def web_path
-          "http://download.virtualbox.org/virtualbox/%{version}/VBoxGuestAdditions_%{version}.iso"
+          "https://download.virtualbox.org/virtualbox/%{version}/VBoxGuestAdditions_%{version}.iso"
         end
 
 


### PR DESCRIPTION
Although this might seem trivial, the VirtualBox download server doesn't redirect HTTP traffic to HTTPS.

To test this one could run:

```
curl -I http://download.virtualbox.org/virtualbox
```

Where the server responds with a `200` code instead of a `301` like it should. To mitigate this, we should just reference the `https://` endpoint like so.