### PR TITLE
Add Missing Required OL 8 Library

### DIFF
--- a/lib/vagrant-vbguest/installers/oracle.rb
+++ b/lib/vagrant-vbguest/installers/oracle.rb
@@ -15,7 +15,8 @@ module VagrantVbguest
           'gcc',
           'make',
           'perl',
-          'bzip2'
+          'bzip2',
+          'elfutils-libelf-devel'
         ].join(' ')
       end
     end


### PR DESCRIPTION
Add the 'elfutils-libelf-devel' library required by Guest Additions on OL 8

Fixes #364 