### PR TITLE
debian: set DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/lib/vagrant-vbguest/installers/debian.rb
+++ b/lib/vagrant-vbguest/installers/debian.rb
@@ -24,7 +24,7 @@ module VagrantVbguest
 
     protected
       def install_dependencies_cmd
-        "apt-get install -y #{dependencies}"
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y #{dependencies}"
       end
 
       def dependencies


### PR DESCRIPTION
Don't prompt for input to prevent hangs when installing dependencies.