### PR TITLE
Defer un-mounting the iso until cleanup

### DIFF
--- a/lib/vagrant-vbguest/installer.rb
+++ b/lib/vagrant-vbguest/installer.rb
@@ -151,7 +151,11 @@ module VagrantVbguest
     end
 
     def cleanup
-      @guest_installer.cleanup if @guest_installer
+      return unless @guest_installer
+
+      @guest_installer.cleanup do |type, data|
+        @env.ui.info(data, :prefix => false, :new_line => false)
+      end
     end
 
     def with_hooks(step_name)

--- a/lib/vagrant-vbguest/installers/base.rb
+++ b/lib/vagrant-vbguest/installers/base.rb
@@ -236,12 +236,13 @@ module VagrantVbguest
 
       # A helper method to delete the uploaded GuestAdditions iso file
       # from the guest box
-      def cleanup
+      def cleanup(opts, &block)
         unless options[:no_cleanup]
           @host.cleanup
-          communicate.execute("test -f #{tmp_path} && rm #{tmp_path}", :error_check => false) do |type, data|
-            env.ui.error(data.chomp, :prefix => false)
-          end
+
+          opts = (opts || {}).merge(:error_check => false)
+          block ||= proc { |type, data| env.ui.error(data.chomp, :prefix => false) }
+          communicate.execute("test -f #{tmp_path} && rm #{tmp_path}", opts, &block)
         end
       end
     end

--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -67,7 +67,6 @@ module VagrantVbguest
         mount_iso(opts, &block)
         execute_installer(opts, &block)
         start(opts, &block)
-        unmount_iso(opts, &block) unless options[:no_cleanup]
       end
 
       # @param opts [Hash] Optional options Hash wich meight get passed to {Vagrant::Communication::SSH#execute} and firends
@@ -268,6 +267,13 @@ module VagrantVbguest
       def unmount_iso(opts=nil, &block)
         env.ui.info(I18n.t("vagrant_vbguest.unmounting_iso", :mount_point => mount_point))
         communicate.sudo("umount #{mount_point}", opts, &block)
+      end
+
+      def cleanup(opts=nil, &block)
+        unless options[:no_cleanup]
+          unmount_iso(opts, &block)
+          super
+        end
       end
     end
   end

--- a/lib/vagrant-vbguest/installers/windows.rb
+++ b/lib/vagrant-vbguest/installers/windows.rb
@@ -51,7 +51,6 @@ module VagrantVbguest
         upload(iso_file)
         mount_iso(opts, &block)
         execute_installer(opts, &block)
-        unmount_iso(opts, &block) unless options[:no_cleanup]
       end
 
       def reboot_after_install?(opts = nil, &block)
@@ -111,6 +110,13 @@ module VagrantVbguest
         env.ui.info(I18n.t("vagrant_vbguest.unmounting_iso",mount_point: mount_point))
         communicate.execute("Dismount-DiskImage -ImagePath #{tmp_path}", opts, &block)
         communicate.execute("Remove-Item -Path #{tmp_path}", opts, &block)
+      end
+
+      def cleanup(opts = nil, &block)
+        unless options[:no_cleanup]
+          unmount_iso(opts, &block)
+          super
+        end
       end
 
       def yield_installation_error_warning(path_to_installer)


### PR DESCRIPTION
… moving it out of the "install" step.
This allows "after_install" hooks to use the mounted iso.