### PR TITLE
vboxguest does not depend on vboxsf - permit to be absent

### DIFF
--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -77,7 +77,7 @@ module VagrantVbguest
         opts = {
           :sudo => true
         }.merge(opts || {})
-        communicate.test('grep -qE "^vboxguest\b.*vboxsf\b" /proc/modules', opts, &block)
+        communicate.test('grep -qE "^vboxguest\b" /proc/modules', opts, &block)
       end
 
       # This overrides {VagrantVbguest::Installers::Base#guest_version}


### PR DESCRIPTION
This PR relaxes what `vbguest` believes to be a correctly-installed plugin.  The original code searched for `vboxguest` followed by a instance of `vboxsf` but it turns out that it is a valid configuration to _not_ use a shared filesystem at all.  In this case, only the `vboxguest` kmod will be loaded, causing a false-negative result on the plugin being correctly installed.  IMHO it is sufficient to only check for the main kmod to demonstrate success, reflected by this PR.  The side effect of this false negative is that `vbguest` does extra work every time the VM is booted to re-compile the kmods.  See attached for the output of [`vagrant vbguest --debug --status`](https://github.com/dotless-de/vagrant-vbguest/files/5631118/debug.txt)