### PR TITLE
Linux kernel modules running check is now configureable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -98,7 +98,11 @@ Vagrant.configure("2") do |config|
   end
 end
 ```
+##### Linux
 
+This option is available on all Linux type installers.
+
+* `:running_kernel_modules` (default: `["vboxguest", "vboxsf"]`) The list used to check for the "running" state. Each of these modules need to appear at the beginning of a line in `/proc/modules`.
 
 ##### CentOS
 


### PR DESCRIPTION
- By default, check for "vboxguest" and “vboxsf" to appear in /proc/modules
- Check using ruby for ease of matching. (No need to deal with different distro grep implementations etc)

closes #396