### PR TITLE
Do not check for errors during cleanup

### DIFF
--- a/lib/vagrant-vbguest/installer.rb
+++ b/lib/vagrant-vbguest/installer.rb
@@ -153,7 +153,7 @@ module VagrantVbguest
     def cleanup
       return unless @guest_installer
 
-      @guest_installer.cleanup do |type, data|
+      @guest_installer.cleanup(:error_check => false) do |type, data|
         @env.ui.info(data, :prefix => false, :new_line => false)
       end
     end

--- a/lib/vagrant-vbguest/installers/base.rb
+++ b/lib/vagrant-vbguest/installers/base.rb
@@ -240,7 +240,6 @@ module VagrantVbguest
         unless options[:no_cleanup]
           @host.cleanup
 
-          opts = (opts || {}).merge(:error_check => false)
           block ||= proc { |type, data| env.ui.error(data.chomp, :prefix => false) }
           communicate.execute("test -f #{tmp_path} && rm #{tmp_path}", opts, &block)
         end


### PR DESCRIPTION
Ref #393

Vagrantfile:

```ruby
Vagrant.configure("2") do |config|
  config.vagrant.plugins = ["vagrant-vbguest"]

  config.vm.box = "ubuntu/hirsute64"

  config.vbguest.installer_hooks[:before_install] = [
    "echo An error occurred >&2; exit 1",
    "apt-get update",
    "apt-get -y install virtualbox-guest-utils",
  ]
end
```

Before:

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

umount /mnt

Stdout from the command:



Stderr from the command:

umount: /mnt: not mounted.
```

After:

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

echo An error occurred >&2; exit 1

Stdout from the command:



Stderr from the command:

An error occurred
```