### PR TITLE
Splat Hash to Keyword args for I18n to be ruby 3 compatible

### DIFF
--- a/lib/vagrant-vbguest/command.rb
+++ b/lib/vagrant-vbguest/command.rb
@@ -94,7 +94,7 @@ module VagrantVbguest
       options = vm.config.vbguest.to_hash.merge(options)
       machine = VagrantVbguest::Machine.new(vm, options)
       status  = machine.state
-      vm.env.ui.send((:ok == status ? :success : :warn), I18n.t("vagrant_vbguest.status.#{status}", machine.info))
+      vm.env.ui.send((:ok == status ? :success : :warn), I18n.t("vagrant_vbguest.status.#{status}", **machine.info))
 
       if _method != :status
         machine.send(_method)

--- a/lib/vagrant-vbguest/installers/base.rb
+++ b/lib/vagrant-vbguest/installers/base.rb
@@ -189,16 +189,18 @@ module VagrantVbguest
       # will start _now_.
       # The message includes the host and installer version strings.
       def yield_installation_warning(path_to_installer)
-        @env.ui.warn I18n.t("vagrant_vbguest.installing#{@options[:force] ? '_forced' : ''}",
-          :guest_version     => (guest_version || I18n.t("vagrant_vbguest.unknown")),
-          :installer_version => installer_version(path_to_installer) || I18n.t("vagrant_vbguest.unknown"))
+        @env.ui.warn I18n.t(
+          "vagrant_vbguest.installing#{@options[:force] ? '_forced' : ''}",
+          guest_version: (guest_version || I18n.t("vagrant_vbguest.unknown")),
+          installer_version: (installer_version(path_to_installer) || I18n.t("vagrant_vbguest.unknown")))
       end
 
       # Helper to yield a warning message to the user, that the installation
       # will be rebuild using the installed GuestAdditions.
       # The message includes the host and installer version strings.
       def yield_rebuild_warning
-        @env.ui.warn I18n.t("vagrant_vbguest.rebuild#{@options[:force] ? '_forced' : ''}",
+        @env.ui.warn I18n.t(
+          "vagrant_vbguest.rebuild#{@options[:force] ? '_forced' : ''}",
           :guest_version => guest_version(true),
           :host_version => @host.version)
       end
@@ -210,8 +212,9 @@ module VagrantVbguest
       # knows there could be a problem. The message includles the installer
       # version.
       def yield_installation_error_warning(path_to_installer)
-        @env.ui.warn I18n.t("vagrant_vbguest.install_error",
-          :installer_version => installer_version(path_to_installer) || I18n.t("vagrant_vbguest.unknown"))
+        @env.ui.warn I18n.t(
+          "vagrant_vbguest.install_error",
+          installer_version: (installer_version(path_to_installer) || I18n.t("vagrant_vbguest.unknown")))
       end
       # alias to old method name (containing a typo) for backwards compatibility
       alias_method :yield_installation_waring, :yield_installation_error_warning
@@ -230,7 +233,7 @@ module VagrantVbguest
       #
       # @param file [String] Path of the file to upload to the +tmp_path*
       def upload(file)
-        env.ui.info(I18n.t("vagrant_vbguest.start_copy_iso", :from => file, :to => tmp_path))
+        env.ui.info(I18n.t("vagrant_vbguest.start_copy_iso", from: file, to: tmp_path))
         communicate.upload(file, tmp_path)
       end
 

--- a/lib/vagrant-vbguest/middleware.rb
+++ b/lib/vagrant-vbguest/middleware.rb
@@ -21,7 +21,7 @@ module VagrantVbguest
       if options[:auto_update]
         machine = VagrantVbguest::Machine.new vm, options
         status  = machine.state
-        vm.env.ui.send((:ok == status ? :success : :warn), I18n.t("vagrant_vbguest.status.#{status}", machine.info))
+        vm.env.ui.send((:ok == status ? :success : :warn), I18n.t("vagrant_vbguest.status.#{status}", **machine.info))
         machine.run
         reboot(vm, options) if machine.reboot?
       end

--- a/vagrant-vbguest.gemspec
+++ b/vagrant-vbguest.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{A Vagrant plugin to install the VirtualBoxAdditions into the guest VM}
   s.description = %q{A Vagrant plugin which automatically installs the host's VirtualBox Guest Additions on the guest system.}
 
+  s.required_ruby_version = ">= 2.0"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "micromachine", ">= 2", "< 4"


### PR DESCRIPTION
Fixes #409

I did a quick sweep through the codebase and fixed all `I18n` calls.  