### PR TITLE
Install build-essential in Debian installer

### DIFF
--- a/lib/vagrant-vbguest/installers/debian.rb
+++ b/lib/vagrant-vbguest/installers/debian.rb
@@ -34,6 +34,8 @@ module VagrantVbguest
         else
           ['linux-headers-`uname -r`']
         end
+        # include build-essential so we can compile the kernel modules.
+        packages << 'build-essential'
         # some Debian system (lenny) don't come with a dkms package so we need to skip that.
         # apt-cache search will exit with 0 even if nothing was found, so we need to grep.
         packages << 'dkms' if communicate.test('apt-cache search --names-only \'^dkms$\' | grep dkms')


### PR DESCRIPTION
If you're trying to use the `vbguest` plugin with a custom debian-flavored box, there's a good chance you don't have `build-essential` installed. This results in the following error if you need to rebuild the kernel modules:
```
==> default: Machine booted and ready!
[default] GuestAdditions seems to be installed (6.1.22) correctly, but not running.
update-initramfs: Generating /boot/initrd.img-5.4.0-77-generic
VirtualBox Guest Additions: Starting.
VirtualBox Guest Additions: Building the VirtualBox Guest Additions kernel
modules.  This may take a while.
VirtualBox Guest Additions: To build modules for other installed kernels, run
VirtualBox Guest Additions:   /sbin/rcvboxadd quicksetup <version>
VirtualBox Guest Additions: or
VirtualBox Guest Additions:   /sbin/rcvboxadd quicksetup all
VirtualBox Guest Additions: Building the modules for kernel 5.4.0-77-generic.

This system is currently not set up to build kernel modules.
Please install the gcc make perl packages from your distribution.
VirtualBox Guest Additions: Running kernel modules will not be replaced until
the system is restarted
Restarting VM to apply changes...
==> default: Attempting graceful shutdown of VM...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: Setting hostname...
==> default: Mounting shared folders...
    default: /vagrant => /Users/cpatton/projects/provision/virtual-machines/foreman
Vagrant was unable to mount VirtualBox shared folders. This is usually
because the filesystem "vboxsf" is not available. This filesystem is
made available via the VirtualBox Guest Additions and kernel module.
Please verify that these guest additions are properly installed in the
guest. This is not a bug in Vagrant and is usually caused by a faulty
Vagrant box. For context, the command attempted was:

mount -t vboxsf -o uid=1000,gid=1000,_netdev vagrant /vagrant

The error output from the command was:

: Invalid argument
```