### PR TITLE
Check for "rocky" as platform

### DIFF
--- a/lib/vagrant-vbguest/installers/redhat.rb
+++ b/lib/vagrant-vbguest/installers/redhat.rb
@@ -5,7 +5,7 @@ module VagrantVbguest
       # fortunately they're probably both similar enough to RHEL
       # (RedHat Enterprise Linux) not to matter.
       def self.match?(vm)
-        /\A(redhat|centos|amazon)\d*\Z/ =~ self.distro(vm)
+        /\A(redhat|centos|amazon|rocky)\d*\Z/ =~ self.distro(vm)
       end
 
       # Install missing deps and yield up to regular linux installation


### PR DESCRIPTION
This change checks to see if the base box platform/distro is Rocky Linux and performs the same installation as RedHat/CentOS.