### PR TITLE
Unreliable test of installed guest additions

### DIFF
--- a/lib/vagrant-vbguest/installers/linux.rb
+++ b/lib/vagrant-vbguest/installers/linux.rb
@@ -77,7 +77,9 @@ module VagrantVbguest
         kmods = nil
         communicate.sudo('cat /proc/modules', opts) do |type, data|
           block.call(type, data) if block
-          kmods = data if type == :stdout && data
+          if type == :stdout && data
+            kmods = kmods.nil? ? data : kmods + data
+          end
         end
 
         unless kmods


### PR DESCRIPTION
Output of `cat /proc/modules` may come in a number of chunks. The current code captures only the last chunk. As a result, the `running?` method may wrongly report that Guest Additions are missing.

vagrant-vbguest plugin tests if Guest Additions are installed every time a VM starts. In my case, the test fails every second time and Guest Additions are reinstalled.